### PR TITLE
[INFRA] add: gitattributes definition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
For source files and scripts we want to always use LF, no CRLF.